### PR TITLE
Fix checkconfig args in indextool

### DIFF
--- a/src/indextool.cpp
+++ b/src/indextool.cpp
@@ -855,7 +855,7 @@ int main ( int argc, char ** argv )
 		OPT1 ( "--build-infixes" )	{ eCommand = CMD_BUILDINFIXES; sIndex = argv[++i]; }
 		OPT1 ( "--build-skips" )	{ eCommand = CMD_BUILDSKIPS; sIndex = argv[++i]; }
 		OPT1 ( "--morph" )			{ eCommand = CMD_MORPH; sIndex = argv[++i]; }
-		OPT1 ( "--checkconfig" )	{ eCommand = CMD_CHECKCONFIG; }
+		OPT1 ( "--checkconfig" )	{ eCommand = CMD_CHECKCONFIG; ++i; } // prevent argc != i
 		OPT1 ( "--optimize-rt-klists" )
 		{
 			eCommand = CMD_OPTIMIZEKLISTS;

--- a/src/indextool.cpp
+++ b/src/indextool.cpp
@@ -842,6 +842,7 @@ int main ( int argc, char ** argv )
 		if ( argv[i][0]!='-' ) break;
 		OPT ( "-q", "--quiet" )		{ bQuiet = true; continue; }
 		OPT1 ( "--strip-path" )		{ bStripPath = true; continue; }
+		OPT1 ( "--checkconfig" )	{ eCommand = CMD_CHECKCONFIG; ++i; } // prevent argc != i
 
 		// handle options/commands with 1+ args
 		if ( (i+1)>=argc )			break;
@@ -855,7 +856,6 @@ int main ( int argc, char ** argv )
 		OPT1 ( "--build-infixes" )	{ eCommand = CMD_BUILDINFIXES; sIndex = argv[++i]; }
 		OPT1 ( "--build-skips" )	{ eCommand = CMD_BUILDSKIPS; sIndex = argv[++i]; }
 		OPT1 ( "--morph" )			{ eCommand = CMD_MORPH; sIndex = argv[++i]; }
-		OPT1 ( "--checkconfig" )	{ eCommand = CMD_CHECKCONFIG; ++i; } // prevent argc != i
 		OPT1 ( "--optimize-rt-klists" )
 		{
 			eCommand = CMD_OPTIMIZEKLISTS;


### PR DESCRIPTION
due to 
if ( i!=argc ) error handling, all the parameter read must increment i, it was not done for checkconfig
https://github.com/sphinxsearch/sphinx/blob/c116ce96f38d17a5aa425ac838e2035e3417fafa/src/indextool.cpp#L941